### PR TITLE
Fixes for Arduino Yun

### DIFF
--- a/BreakfastSerial/BreakfastSerial.py
+++ b/BreakfastSerial/BreakfastSerial.py
@@ -35,6 +35,10 @@ class Arduino(pyfirmata.Arduino):
             newargs = (find_arduino(),)
             super(Arduino, self).__init__(*newargs)
 
+        # Get protocol version
+        self.sp.write(chr(0xF9))        
+        self.iterate()              
+
         if not self.get_firmata_version():
             raise FirmataNotOnBoardException
 

--- a/BreakfastSerial/BreakfastSerial.py
+++ b/BreakfastSerial/BreakfastSerial.py
@@ -36,8 +36,10 @@ class Arduino(pyfirmata.Arduino):
             super(Arduino, self).__init__(*newargs)
 
         # Get protocol version
-        self.sp.write(chr(0xF9))        
-        self.iterate()              
+        self.sp.write(chr(0xF9))
+        self.pass_time(1)
+        while self.bytes_available():                 
+            self.iterate()
 
         if not self.get_firmata_version():
             raise FirmataNotOnBoardException

--- a/BreakfastSerial/components.py
+++ b/BreakfastSerial/components.py
@@ -75,6 +75,7 @@ class Led(Component):
         super(Led, self).__init__(board, pin)
         self._isOn = False
         self._interval = None
+        self._pin.mode = pyfirmata.OUTPUT
 
     def on(self):
         self._pin.write(1)


### PR DESCRIPTION
Hi Swift,

I had two issues with BreakfastSerial and Yun board using StandardFirmata 2.3 (bundled with Arduino IDE 1.5.4):
- initialization was failing with `FirmataNotOnBoardException` due to empty `firmata_version` property. It could be caused by changes in Firmata protocol, because 2.3 only responds with queryFirmware (`0x79`) which sets `firmware` and `firmware_version`. Also it's only done after boot, so I added protocol version query on init.
- setting LED value didn't work without setting port mode to output, so I also added it in `Led` init.

I don't have any board other than Yun, so I'm unable to tell if these changes broke anything on other boards :(
